### PR TITLE
Fix an issue where the context was being recreated each time

### DIFF
--- a/EntityFrameworkCoreinAction/Chapter08.md
+++ b/EntityFrameworkCoreinAction/Chapter08.md
@@ -1,0 +1,66 @@
+# Chapter 8 - Configuring advanced features and handling concurrency conflicts
+
+## 8.1 Advanced feature - using backing fields with relationships
+
+- Backing fields are essentially ways to add additional validation to a property by preventing the devs from accessing it directly
+
+### 8.1.1 The problem - the book app performance is too slow
+
+- Each time a book is brought up, the system has to average all of the current votes for the reviews. The author points out this could be optimized by stashing that calculation in a property
+- If it's in a precalculated state, then we'll have to update it each time a review is added or removed
+- We will learn a potentially better method in section 13.4.2, but for now this will do
+
+### 8.1.2 Our solution - `IEnumerable<Review>` property and a backing field
+
+- Change the `ICollection<Review>` to an `IEnumerable<Review>`, which will remove the `Add` and `Remove` methods from the collection and hide the real collection in a backing field
+- Create an `AddReview` and `RemoveReview` method to the `Book` entity
+- You can name the backing field `_reviews` and EF Core should configure it by convention
+- The add and remove methods should update a `CachedVotes` property each time they are called
+- You must add some configuration to the fluent API to ensure EF Core will write to the backing field
+
+```c#
+entity.Metadata
+    .FindNavigation(nameof(Ch07Book.Reviews))
+    .SetPropertyAccessMode(PropertyAccessMode.Field);
+```
+
+## 8.2 DbFunction - using user-defined functions with EF Core
+
+- UDFs = User-Defined Functions
+- Allow you to write SQL code that will be run on the db server; moves a calculation from client-side to server which can be faster since the db can access the rows directly
+- _Database scalar function mapping_ (DbFunction) allows you to reference a UDF in the db as if it were a local method in code
+- These are very useful for performance tuning
+- You must manually add the UDF into the database using an SQL Command
+- Declare a method in the application's DbContext or in a separate class with the proper configuration
+- You can then use the UDF reference in a query and EF core will convert it into a db call to the SQL query
+
+### 8.2.1 Configuring a scalar user-defined function
+
+- A static method matching the SQL method and registered with EF Core at config time
+- The name of the static method should match the UDF, but can be configured otherwise
+- The number, type and order of the parameters must match the parameters of the UDF
+- _Name of the parameters does not need to match_
+- Register in one of two ways:
+  - Use the `DbFunctionAttribute` on the method
+  - Use the Fluent API
+
+```c#
+// DbFunctionAttribute
+[DbFunction]
+public static double? AverageVotes(int id)
+{
+    //some code
+}
+
+// Fluent API
+modelBuilder.HasDbFunction(
+    () => WrappingClassName.AverageVotes(default(int))
+);
+```
+
+- The method in the `HasDbFunction` call isn't actually called, but reflection is used to find the name, return type, and parameters of the method
+
+### 8.2.2 Adding your UDF code to the database
+
+- You must manually add the UDFs to the database with SQL
+- You can leverage migrations to do this, but that is discussed in chapter 11

--- a/Web/BookClub.Repo/BookClubDbContext.cs
+++ b/Web/BookClub.Repo/BookClubDbContext.cs
@@ -13,9 +13,12 @@ namespace Repo
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.ApplyConfiguration(new BookConfig());
+            modelBuilder
+                .ApplyConfiguration(new BookConfig())
+                .ApplyConfiguration(new AuthorConfig());
         }
 
         public DbSet<Book> Books { get; set; }
+        public DbSet<Author> Authors { get; set; }
     }
 }

--- a/Web/BookClub.Repo/Configs/AuthorConfig.cs
+++ b/Web/BookClub.Repo/Configs/AuthorConfig.cs
@@ -1,0 +1,16 @@
+using Microsoft.EntityFrameworkCore;
+using Repo.Models;
+
+namespace Repo.Configs
+{
+    public class AuthorConfig : IEntityTypeConfiguration<Author>
+    {
+        public void Configure(Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder<Author> builder)
+        {
+            builder.HasKey(a => a.AuthorId);
+
+            builder.Property(a => a.AuthorId)
+                .ValueGeneratedOnAdd();
+        }
+    }
+}

--- a/Web/BookClub.Repo/DbCreator.cs
+++ b/Web/BookClub.Repo/DbCreator.cs
@@ -7,11 +7,18 @@ namespace Repo
 {
     public static class DbCreator
     {
+        private static Author[] SeedAuthors = new Author[]
+        {
+            new Author { Name = "Jon Skeet" },
+            new Author { Name = "Jon P Smith" },
+            new Author { Name = "Andrew Lock" }
+        };
+
         private static Book[] SeedBooks = new Book[]
         {
-            new Book { Name = "C# in Depth", Edition = "Fourth", Author = "Jon Skeet", Complete = true, Image = "https://csharpindepth.com/images/Cover.png" },
-            new Book { Name = "Entity Framework Core in Action", Author = "Jon P Smith", Edition = "First", Current = true, Image = "https://images.manning.com/360/480/resize/book/2/2cd7852-84a5-44f5-a05b-451d68478e31/Smith-EFC-HI.png" },
-            new Book { Name = "ASP.NET Core in Action", Author = "Andrew Lock", Edition = "First", Complete = true, Image = "https://images.manning.com/360/480/resize/book/3/a3544c6-0057-465a-a17e-d1fbd7f61b80/Lock-ANCore-HI.png" }
+            new Book { Name = "C# in Depth", Edition = "Fourth", Author = SeedAuthors.Single(x => x.Name == "Jon Skeet"), Complete = true, Image = "https://csharpindepth.com/images/Cover.png" },
+            new Book { Name = "Entity Framework Core in Action", Author = SeedAuthors.Single(x => x.Name == "Jon P Smith"), Edition = "First", Current = true, Image = "https://images.manning.com/360/480/resize/book/2/2cd7852-84a5-44f5-a05b-451d68478e31/Smith-EFC-HI.png" },
+            new Book { Name = "ASP.NET Core in Action", Author = SeedAuthors.Single(x => x.Name == "Andrew Lock"), Edition = "First", Complete = true, Image = "https://images.manning.com/360/480/resize/book/3/a3544c6-0057-465a-a17e-d1fbd7f61b80/Lock-ANCore-HI.png" }
         };
 
         public static DbContextOptionsBuilder CreateDb(this DbContextOptionsBuilder optionsBuilder)
@@ -44,6 +51,9 @@ namespace Repo
 
         private static void SeedDatabase(BookClubDbContext context)
         {
+            context.Authors.AddRange(SeedAuthors);
+            context.SaveChanges();
+
             context.Books.AddRange(SeedBooks);
             context.SaveChanges();
         }

--- a/Web/BookClub.Repo/Models/Author.cs
+++ b/Web/BookClub.Repo/Models/Author.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace Repo.Models
+{
+    public class Author
+    {
+        public string AuthorId { get; set; }
+        public string Name { get; set; }
+        public ICollection<Book> Books { get; set; }
+    }
+}

--- a/Web/BookClub.Repo/Models/Book.cs
+++ b/Web/BookClub.Repo/Models/Book.cs
@@ -8,10 +8,10 @@ namespace Repo.Models
         [Required]
         public string Name { get; set; }
         public string Edition { get; set; }
-        [Required]
-        public string Author { get; set; }
         public string Image { get; set; }
         public bool Current { get; set; }
         public bool Complete { get; set; }
+        [Required]
+        public Author Author { get; set; }
     }
 }

--- a/Web/BookClub.Repo/Repo.csproj
+++ b/Web/BookClub.Repo/Repo.csproj
@@ -5,6 +5,7 @@
     <UserSecretsId>dcc1a1fe-fdc7-4196-a8bb-03185b3806c9</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Cosmos" Version="3.1.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.6" />

--- a/Web/BookClub/Controllers/HomeController.cs
+++ b/Web/BookClub/Controllers/HomeController.cs
@@ -1,5 +1,6 @@
 ﻿using BookClub.Models;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Repo;
 using System.Diagnostics;
 
@@ -8,7 +9,7 @@ namespace BookClub.Controllers
     public class HomeController : Controller
     {
         public IActionResult Index([FromServices] BookClubDbContext context)
-            => View(context.Books);
+            => View(context.Books.Include(b => b.Author));
 
         [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
         public IActionResult Error()

--- a/Web/BookClub/Program.cs
+++ b/Web/BookClub/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
+using Repo;
 
 namespace BookClub
 {
@@ -9,6 +10,7 @@ namespace BookClub
         {
             CreateHostBuilder(args)
                 .Build()
+                .CreateDb()
                 .Run();
         }
 

--- a/Web/BookClub/Startup.cs
+++ b/Web/BookClub/Startup.cs
@@ -24,7 +24,7 @@ namespace BookClub
         {
             services.AddControllersWithViews();
 
-            services.AddDbContext<BookClubDbContext>(opt => opt.CreateDb());
+            services.AddDbContext<BookClubDbContext>(opt => opt.ConfigureDb());
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/Web/BookClub/Views/Home/Index.cshtml
+++ b/Web/BookClub/Views/Home/Index.cshtml
@@ -11,7 +11,14 @@
     </p>
 </div>
 
-@foreach(var book in Model)
-{
-    <img class="img-responsive" height="140" src="@book.Image" alt="@book.Name" />
-}
+<div class="d-flex">
+    @foreach(var book in Model)
+    {
+        <div class="d-flex flex-column border rounded p-2 m-1" style="width: 130px;">
+            <img class="img-responsive" height="140" src="@book.Image" alt="@book.Name" />
+            <strong>@book.Name</strong>
+            <span>@book.Author.Name</span>
+        </div>
+    }
+</div>
+


### PR DESCRIPTION
If you were to load the site then refresh, an error would occur because the context was being re-created each time and a new in-memory database was generated.

The logic has been split out into a separate function that can be called directly in the `Program.cs` file, which is a much better way of doing things